### PR TITLE
fix: lowercase ghcr image ref for cosign signing

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_REPO: luthor-ai-systems-framework
 
 jobs:
   build-push-sign:
@@ -23,6 +23,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Normalize GHCR path to lowercase (Cosign requires this)
+      - name: Set image vars (lowercase)
+        run: |
+          echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+          echo "IMAGE=${{ env.REGISTRY }}/${GITHUB_REPOSITORY_OWNER,,}/${{ env.IMAGE_REPO }}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,7 +44,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -57,7 +63,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.build.outputs.digest }}
 
       # Keyless signing (Cosign) using GitHub OIDC (no keys stored)
@@ -68,14 +74,14 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          IMAGE="${{ env.IMAGE }}@${{ steps.build.outputs.digest }}"
           cosign sign --yes "$IMAGE"
 
       - name: Verify signature (sanity check)
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          IMAGE="${{ env.IMAGE }}@${{ steps.build.outputs.digest }}"
           cosign verify \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release-image.yml@refs/heads/main" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \


### PR DESCRIPTION
## What
Fix Release Image workflow to use lowercase GHCR image references.

## Why
Cosign requires OCI image references to be lowercase. Using `ghcr.io/RisaLuthor/...` caused signing to fail.

## Changes
- Normalize GHCR image path to lowercase via workflow env
- Use a single `${IMAGE}@${digest}` reference for signing and verification